### PR TITLE
Enables the pure-ftpwho tool ...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,63 @@
 # docker-pureftpd
 # Copyright (C) 2016  gimoh
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-FROM alpine:3.3
+FROM alpine:3.4
 MAINTAINER gimoh <gimoh@bitmessage.ch>
 
-ENV PUREFTPD_VERSION=1.0.42-r0 \
+ENV PUREFTPD_VERSION=1.0.42 \
+    PUREFTPD_SHASUM=5a8e4bd0801331f5f58023ffb586eefea9aa4950 \
     SYSLOG_STDOUT_VERSION=1.1.1 \
+    SYSLOG_STDOUT_SHASUM=194c1ec1172dfd822429bfb7a3834f0d97887c15 \
     PURE_CONFDIR=/etc/pureftpd
 
-RUN url_join() { local pifs="${IFS}"; IFS=/; echo "$*"; IFS="${pifs}"; } \
-    && printf '%s\n' \
-      '@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing' \
-      >> /etc/apk/repositories \
-    && apk update \
-    && apk add pure-ftpd@testing="${PUREFTPD_VERSION}" \
-    && apk add curl=7.49.1-r0 \
+RUN set -uex \
+    && apk add --no-cache --virtual .build-deps \
+       curl \
+       ca-certificates \
+       gcc \
+       make \
+       musl-dev \
+       openssl \
+       \
+    && addgroup _pure-ftpd \
+    && adduser -G _pure-ftpd -s /sbin/nologin -h /var/empty -D _pure-ftpd \
+    \
+    && cd /tmp \
+    && curl -LO https://github.com/timonier/syslog-stdout/releases/download/v"${SYSLOG_STDOUT_VERSION}"/syslog-stdout.tar.gz \
+    && echo "${SYSLOG_STDOUT_SHASUM}  syslog-stdout.tar.gz" | sha1sum -c - \
     && install -d -o root -g root -m 755 /usr/local/sbin \
-    && curl -ksL \
-      "$(url_join \
-        https://github.com/timonier/syslog-stdout/releases/download \
-        "v${SYSLOG_STDOUT_VERSION}" \
-        syslog-stdout.tar.gz)" \
-      |tar -xvzf - -C /usr/local/sbin \
-    && apk del --purge curl \
-    && rm -rf /var/cache/apk/*
+    && tar -C /usr/local/sbin -xzf syslog-stdout.tar.gz \
+    \
+    && cd /tmp \
+    && curl -LO https://download.pureftpd.org/pub/pure-ftpd/releases/pure-ftpd-"${PUREFTPD_VERSION}".tar.gz \
+    && echo "${PUREFTPD_SHASUM}  pure-ftpd-${PUREFTPD_VERSION}.tar.gz" | sha1sum -c - \
+    && tar -xzf pure-ftpd-"${PUREFTPD_VERSION}".tar.gz \
+    \
+    && cd /tmp/pure-ftpd-"${PUREFTPD_VERSION}" \
+    && ./configure --prefix=/usr \
+      --without-humor \
+      --without-unicode \
+      --with-minimal \
+      --with-throttling  \
+      --with-puredb \
+      --with-ftpwho \
+    && make install-strip \
+    \
+    && apk del .build-deps \
+    && rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
 
 # user ftpv and /srv/ftp for virtual users, user ftp and /var/lib/ftp
 # for anonymous; these are separate so anonymous cannot read/write

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,11 +45,10 @@ RUN set -uex \
     \
     && cd /tmp/pure-ftpd-"${PUREFTPD_VERSION}" \
     && ./configure --prefix=/usr \
-      --sysconfdir=/etc/pureftpd \
+      --sysconfdir="${PURE_CONFDIR}" \
       --without-humor \
-      --without-unicode \
-      --with-minimal \
-      --with-throttling  \
+      --without-inetd \
+      --with-throttling \
       --with-puredb \
       --with-ftpwho \
     && make install-strip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,6 @@ RUN set -uex \
        musl-dev \
        openssl \
        \
-    && addgroup _pure-ftpd \
-    && adduser -G _pure-ftpd -s /sbin/nologin -h /var/empty -D _pure-ftpd \
-    \
     && cd /tmp \
     && curl -LO https://github.com/timonier/syslog-stdout/releases/download/v"${SYSLOG_STDOUT_VERSION}"/syslog-stdout.tar.gz \
     && echo "${SYSLOG_STDOUT_SHASUM}  syslog-stdout.tar.gz" | sha1sum -c - \
@@ -48,6 +45,7 @@ RUN set -uex \
     \
     && cd /tmp/pure-ftpd-"${PUREFTPD_VERSION}" \
     && ./configure --prefix=/usr \
+      --sysconfdir=/etc/pureftpd \
       --without-humor \
       --without-unicode \
       --with-minimal \

--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ auto-create their home directories:
       gimoh/pureftpd \
       -j
 
-Note that it's better to also use `PURE_VIRT_USER_HOME_PATTERN` like:
+Note that it's better to use `PURE_VIRT_USER_HOME_PATTERN` like:
 
     docker run -d \
-      -e PURE_USERS=isolated+noanon+virt \
+      -e PURE_USERS=isolated+noanon \
       -e PURE_VIRT_USER_HOME_PATTERN=/srv/ftp/@USER@/./@USER@ \
       --name=ftpd \
       gimoh/pureftpd \

--- a/dkr-init.sh
+++ b/dkr-init.sh
@@ -1,17 +1,17 @@
 #!/bin/sh
 # docker-pureftpd
 # Copyright (C) 2016  gimoh
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
@@ -44,12 +44,12 @@ configure() {
   fi
 
   printf 'export %s="%s"\n' \
+    PURE_PASSWDFILE "${PURE_PASSWDFILE}" \
     PURE_DBFILE "${PURE_DBFILE}" \
+    PURE_VIRT_USER_HOME_PATTERN "${PURE_VIRT_USER_HOME_PATTERN}" \
     PURE_LDAP_CONFIG "${PURE_LDAP_CONFIG}" \
     PURE_MYSQL_CONFIG "${PURE_MYSQL_CONFIG}" \
-    PURE_PASSWDFILE "${PURE_PASSWDFILE}" \
     PURE_PGSQL_CONFIG "${PURE_PGSQL_CONFIG}" \
-    PURE_VIRT_USER_HOME_PATTERN "${PURE_VIRT_USER_HOME_PATTERN}" \
     > "${PURE_CONFDIR}/pure_settings.sh"
 }
 

--- a/pure_defaults.sh
+++ b/pure_defaults.sh
@@ -1,17 +1,17 @@
 #!/bin/sh
 # docker-pureftpd
 # Copyright (C) 2016  gimoh
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -27,11 +27,11 @@ fi
 # globally (run, exec, etc.), these are set here because they are
 # derived from PURE_CONFDIR and we want those changes to propagate (on
 # the first run anyways).
-: ${PURE_DBFILE:=${PURE_CONFDIR}/passwd.pdb} \
-  ${PURE_LDAP_CONFIG:=${PURE_CONFDIR}/ldap.conf} \
-  ${PURE_MYSQL_CONFIG:=${PURE_CONFDIR}/mysql.conf} \
-  ${PURE_PASSWDFILE:=${PURE_CONFDIR}/passwd} \
-  ${PURE_PGSQL_CONFIG:=${PURE_CONFDIR}/pgsql.conf}
+: ${PURE_PASSWDFILE:=${PURE_CONFDIR}/pureftpd.passwd} \
+  ${PURE_DBFILE:=${PURE_CONFDIR}/pureftpd.pdb} \
+  ${PURE_LDAP_CONFIG:=${PURE_CONFDIR}/pureftpd-ldap.conf} \
+  ${PURE_MYSQL_CONFIG:=${PURE_CONFDIR}/pureftpd-mysql.conf} \
+  ${PURE_PGSQL_CONFIG:=${PURE_CONFDIR}/pureftpd-pgsql.conf}
 
 # Mark variables for export so they can be accessed by subprocesses
 export PURE_CONFDIR PURE_DBFILE PURE_LDAP_CONFIG PURE_MYSQL_CONFIG \


### PR DESCRIPTION
In order to get the `pure-ftpwho` command working I needed to recompile pure-ftpd with the `--with-ftpwho` option ...
